### PR TITLE
feat: Implement GET /api/v1/projects/:id endpoint

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -84,6 +84,7 @@ func Serve() {
 				projectRouter.DELETE("/:id", project.ProjectCreatorPermMiddleware(), project.DeleteProject)
 				projectRouter.POST("/:id/receive", project.ReceiveProjectMiddleware(), project.ReceiveProject)
 				projectRouter.GET("/received", project.ListReceiveHistory)
+				projectRouter.GET("/:id", project.GetProject) // New route for getting a specific project
 			}
 
 			// Tag


### PR DESCRIPTION
This commit introduces a new API endpoint to retrieve detailed information for a specific project.

The endpoint `GET /api/v1/projects/:id` provides:
- Complete project details, including creator information.
- A list of tags associated with the project.
- The claiming status, including the total number of items in the project and the number of items that have already been claimed.

The implementation includes:
- A new handler function `GetProject` in `internal/apps/project/routers.go`.
- A response struct `GetProjectResponseData` to structure the returned data.
- Database queries to fetch project data, tags, and item counts.
- Registration of the new route in `internal/router/router.go`, protected by authentication.
- Swagger API documentation for the new endpoint.